### PR TITLE
Add OpenAI token count for allOf field

### DIFF
--- a/schema_agents/utils/token_counter.py
+++ b/schema_agents/utils/token_counter.py
@@ -137,6 +137,10 @@ def num_tokens_from_functions(functions, encoding):
                             function_tokens += 2
                             for any_of in v['anyOf']:
                                 function_tokens += len(encoding.encode(str(any_of)))
+                        elif field == 'allOf':
+                            function_tokens += 2
+                            for all_of in v['allOf']:
+                                function_tokens += len(encoding.encode(str(all_of)))
                         elif field == 'default':
                             function_tokens += 2
                             function_tokens += len(encoding.encode(str(v['default'])))


### PR DESCRIPTION
Very simple PR: add token count for allOf field in JSON schemas used with OpenAI's API. Currently, a warning is printed every time the allOf field is used.